### PR TITLE
Check that we're in the browser before registering web components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18698,7 +18698,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.0.2-alpha.9",
+      "version": "1.0.2-alpha.10",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18698,7 +18698,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.0.2-alpha.10",
+      "version": "1.0.2-alpha.11",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.0.2-alpha.9",
+  "version": "1.0.2-alpha.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.0.2-alpha.9",
+      "version": "1.0.2-alpha.10",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.0.2-alpha.10",
+  "version": "1.0.2-alpha.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.0.2-alpha.10",
+      "version": "1.0.2-alpha.11",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.0.2-alpha.9",
+  "version": "1.0.2-alpha.10",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.0.2-alpha.10",
+  "version": "1.0.2-alpha.11",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/src/web-component.js
+++ b/package/src/web-component.js
@@ -13,57 +13,61 @@ if (typeof window === "object" && !window.Userfront) {
   window.Userfront = Userfront;
 }
 
-/* Define the <foo-form> custom elements */
-customElements.define(
-  "signup-form",
-  r2wc(SignupForm, {
-    props: {
-      tenantId: "string",
-      flow: "json",
-      compact: "boolean",
-      redirect: "string",
-      redirectOnLoadIfLoggedIn: "boolean",
-      xstateDevTools: "boolean",
-    },
-  })
-);
+// Register custom elements if we're in the browser.
+// (Skip for SSR scenarios.)
+if (typeof window === "object" && window.customElements) {
+  /* Define the <foo-form> custom elements */
+  customElements.define(
+    "signup-form",
+    r2wc(SignupForm, {
+      props: {
+        tenantId: "string",
+        flow: "json",
+        compact: "boolean",
+        redirect: "string",
+        redirectOnLoadIfLoggedIn: "boolean",
+        xstateDevTools: "boolean",
+      },
+    })
+  );
 
-customElements.define(
-  "login-form",
-  r2wc(LoginForm, {
-    props: {
-      tenantId: "string",
-      flow: "json",
-      compact: "boolean",
-      redirect: "string",
-      redirectOnLoadIfLoggedIn: "boolean",
-      xstateDevTools: "boolean",
-    },
-  })
-);
+  customElements.define(
+    "login-form",
+    r2wc(LoginForm, {
+      props: {
+        tenantId: "string",
+        flow: "json",
+        compact: "boolean",
+        redirect: "string",
+        redirectOnLoadIfLoggedIn: "boolean",
+        xstateDevTools: "boolean",
+      },
+    })
+  );
 
-customElements.define(
-  "password-reset-form",
-  r2wc(PasswordResetForm, {
-    props: {
-      tenantId: "string",
-      flow: "json",
-      compact: "boolean",
-      redirect: "string",
-      redirectOnLoadIfLoggedIn: "boolean",
-      xstateDevTools: "boolean",
-    },
-  })
-);
+  customElements.define(
+    "password-reset-form",
+    r2wc(PasswordResetForm, {
+      props: {
+        tenantId: "string",
+        flow: "json",
+        compact: "boolean",
+        redirect: "string",
+        redirectOnLoadIfLoggedIn: "boolean",
+        xstateDevTools: "boolean",
+      },
+    })
+  );
 
-customElements.define(
-  "logout-button",
-  r2wc(LogoutButton, {
-    props: {
-      disabled: "boolean",
-      redirect: "string",
-    },
-  })
-);
+  customElements.define(
+    "logout-button",
+    r2wc(LogoutButton, {
+      props: {
+        disabled: "boolean",
+        redirect: "string",
+      },
+    })
+  );
+}
 
 export default Userfront;


### PR DESCRIPTION
Glance

- Before registering custom elements, check that we're in the browser or a compatible environment.
  - Prevents throwing when run on the server since `customElements` is not present there

Patches up the issue for now. As a future enhancement we could use Stencil for the Web Components, which [has some custom server-side rendering support](https://stenciljs.com/docs/hydrate-app). 