### PR TITLE
[DX] TypeScript Compiler: `--preserveWatchOutput` flag

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev-build": "node ./build/watch.cjs",
-    "dev-tsc": "tsc --watch --noEmit",
+    "dev-tsc": "tsc --watch --preserveWatchOutput --noEmit",
     "dev": "npm-run-all --parallel dev-tsc dev-build",
     "build": "tsc && node ./build/build.cjs && npm run build-types",
     "build-types": "tsc src/**/*.{js,jsx} --declaration --allowJs --emitDeclarationOnly --outDir dist; cp types/index.d.ts dist/index.d.ts; cp types/index.d.ts dist/react.d.ts",
@@ -58,8 +58,6 @@
     "@userfront/core": "^0.6.5-beta.1",
     "@xstate/react": "3.0.1",
     "lodash": "^4.17.21",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",
     "react-phone-input-2": "^2.15.1",
     "urlon": "^3.1.0",
@@ -96,5 +94,9 @@
     "vite-plugin-css-injected-by-js": "^3.3.0",
     "vite-plugin-dts": "^1.6.4",
     "vitest": "^0.24.3"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
In this pull request, I enabled preservation of the watch output for the TypeScript compiler under `packages/package.json:11`.

# Motivation

As a developer, I'm unable to read console warnings/errors or have sufficient feedback from running the project locally such as the current host/port. The TypeScript Compiler, by default, clears the console in watch mode. To disable this feature, we need to add the `--preserveWatchOutput` flag.