### PR TITLE
[DX] TypeScript Compiler: `--preserveWatchOutput` flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18698,7 +18698,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.0.3",
+      "version": "1.0.4-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",
@@ -19011,6 +19011,33 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "site/node_modules/@userfront/toolkit": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@userfront/toolkit/-/toolkit-1.0.2.tgz",
+      "integrity": "sha512-z9CYlLwedxv8nXw7MXMXy206DP8bvqyN6FpuRnvgFo8MoNmI5jWXMaHN/ER3RzpMAmVo8hW77UCbK+xGFzjtEQ==",
+      "dependencies": {
+        "@r2wc/react-to-web-component": "^2.0.2",
+        "@react-hook/resize-observer": "^1.2.6",
+        "@userfront/core": "^0.6.5-beta.1",
+        "@xstate/react": "3.0.1",
+        "lodash": "^4.17.21",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-icons": "^4.4.0",
+        "react-phone-input-2": "^2.15.1",
+        "urlon": "^3.1.0",
+        "xstate": "4.33.6"
+      }
+    },
+    "site/node_modules/@userfront/toolkit/node_modules/xstate": {
+      "version": "4.33.6",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.33.6.tgz",
+      "integrity": "sha512-A5R4fsVKADWogK2a43ssu8Fz1AF077SfrKP1ZNyDBD8lNa/l4zfR//Luofp5GSWehOQr36Jp0k2z7b+sH2ivyg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
       }
     },
     "site/node_modules/@vitejs/plugin-react": {
@@ -31261,6 +31288,31 @@
           "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
           "dev": true,
           "optional": true
+        },
+        "@userfront/toolkit": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@userfront/toolkit/-/toolkit-1.0.2.tgz",
+          "integrity": "sha512-z9CYlLwedxv8nXw7MXMXy206DP8bvqyN6FpuRnvgFo8MoNmI5jWXMaHN/ER3RzpMAmVo8hW77UCbK+xGFzjtEQ==",
+          "requires": {
+            "@r2wc/react-to-web-component": "^2.0.2",
+            "@react-hook/resize-observer": "^1.2.6",
+            "@userfront/core": "^0.6.5-beta.1",
+            "@xstate/react": "3.0.1",
+            "lodash": "^4.17.21",
+            "react": "^18.2.0",
+            "react-dom": "^18.2.0",
+            "react-icons": "^4.4.0",
+            "react-phone-input-2": "^2.15.1",
+            "urlon": "^3.1.0",
+            "xstate": "4.33.6"
+          },
+          "dependencies": {
+            "xstate": {
+              "version": "4.33.6",
+              "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.33.6.tgz",
+              "integrity": "sha512-A5R4fsVKADWogK2a43ssu8Fz1AF077SfrKP1ZNyDBD8lNa/l4zfR//Luofp5GSWehOQr36Jp0k2z7b+sH2ivyg=="
+            }
+          }
         },
         "@vitejs/plugin-react": {
           "version": "2.2.0",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.0.3",
+  "version": "1.0.4-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.0.3",
+      "version": "1.0.4-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.0.3",
+  "version": "1.0.4-alpha.0",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/package.json
+++ b/package/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev-build": "node ./build/watch.cjs",
-    "dev-tsc": "tsc --watch --noEmit",
+    "dev-tsc": "tsc --watch --preserveWatchOutput --noEmit",
     "dev": "npm-run-all --parallel dev-tsc dev-build",
     "build": "tsc && node ./build/build.cjs && npm run build-types",
     "build-types": "tsc src/**/*.{js,jsx} --declaration --allowJs --emitDeclarationOnly --outDir dist; cp types/index.d.ts dist/index.d.ts; cp types/index.d.ts dist/react.d.ts",


### PR DESCRIPTION
In this pull request, I enabled preservation of the watch output for the TypeScript compiler under `packages/package.json:11`.

# Motivation

As a developer, I'm unable to read console warnings/errors or have sufficient feedback from running the project locally such as the current host/port. The TypeScript Compiler, by default, clears the console in watch mode. To disable this feature, we need to add the `--preserveWatchOutput` flag.