### PR TITLE
Added cases for states that hadn't been accounted for

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18707,7 +18707,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.0.6-alpha.1",
+      "version": "1.0.6-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.0.6-alpha.1",
+  "version": "1.0.6-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.0.6-alpha.1",
+      "version": "1.0.6-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.0.6-alpha.1",
+  "version": "1.0.6-alpha.2",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/src/forms/UniversalForm.jsx
+++ b/package/src/forms/UniversalForm.jsx
@@ -183,11 +183,14 @@ const componentForStep = (state) => {
   switch (step) {
     case "init":
     case "getGlobalTenantId":
+    case "initUserfront":
+    case "initFlow":
     case "initForm":
     case "beginFlow":
     case "showPreviewAndFetchFlow":
     case "showPlaceholderAndFetchFlow":
     case "initPasswordReset":
+    case "handleLoginWithLink":
       if (canShowFlow) {
         return {
           title: strings[type].title,
@@ -207,6 +210,7 @@ const componentForStep = (state) => {
           Component: Placeholder,
         };
       }
+    case "noFirstFactors":
     case "disabled":
       return {
         title: strings.general.disabled,


### PR DESCRIPTION
Review: Glance
Closes DEV-635

In the toolkit state management the default case is the "Oops, something went wrong" error. There were a couple states in the state machine that didn't have cases in the `UniversalForm` so the defaulted to this error. Specifically for this error `handleLoginWithLink`. I added the missing cases to the `UniversalForm`:
- `handleLoginWithLink`
- `noFirstFactors`
- `initUserfront`
- `initFlow`