### PR TITLE
Show placeholder when resolving links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18707,7 +18707,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.0.6-alpha.2",
+      "version": "1.0.6-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.0.6-alpha.2",
+  "version": "1.0.6-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.0.6-alpha.2",
+      "version": "1.0.6-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.0.6-alpha.2",
+  "version": "1.0.6-alpha.3",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/src/forms/UniversalForm.jsx
+++ b/package/src/forms/UniversalForm.jsx
@@ -190,7 +190,6 @@ const componentForStep = (state) => {
     case "showPreviewAndFetchFlow":
     case "showPlaceholderAndFetchFlow":
     case "initPasswordReset":
-    case "handleLoginWithLink":
       if (canShowFlow) {
         return {
           title: strings[type].title,
@@ -210,6 +209,10 @@ const componentForStep = (state) => {
           Component: Placeholder,
         };
       }
+    case "handleLoginWithLink":
+      return {
+        Component: Placeholder,
+      };
     case "noFirstFactors":
     case "disabled":
       return {


### PR DESCRIPTION
Resolves DEV-635
Review: Glance

Instead of possibly flashing a preview form just show the placeholder when processing links.