### PR TITLE
Enable test mode message on demo form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18707,7 +18707,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.1.0-alpha.1",
+      "version": "1.1.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.1.0-alpha.1",
+      "version": "1.1.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/src/forms/UniversalForm.jsx
+++ b/package/src/forms/UniversalForm.jsx
@@ -568,7 +568,7 @@ const UniversalForm = ({
   theme = {},
   state,
   isDemo = false,
-  demoState = "live",
+  demoMode = "live",
   onEvent,
 }) => {
   // Apply CSS classes based on the size of the form's container
@@ -667,7 +667,7 @@ const UniversalForm = ({
       <Component onEvent={onEvent} {...defaultProps} {...props} />
       <div>
         <SecuredByUserfront
-          mode={isDemo ? demoState : state.context.config?.mode}
+          mode={isDemo ? demoMode : state.context.config?.mode}
         />
       </div>
     </div>


### PR DESCRIPTION
Review level: Glance
Noticed in DEV-993

Fixed a mismatch in prop names, DemoForm passed it in as demoMode, UnboundUniversalForm received it as demoState (I felt demoMode was the better of the two names).