### PR TITLE
If logged in with link credentials don't require current password

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18707,7 +18707,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.0.8",
+      "version": "1.0.9-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.0.8",
+  "version": "1.0.9-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.0.8",
+      "version": "1.0.9-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.0.8",
+  "version": "1.0.9-alpha.0",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/src/forms/UniversalForm.jsx
+++ b/package/src/forms/UniversalForm.jsx
@@ -22,7 +22,7 @@ import { log } from "../services/logging";
 import { useState } from "react";
 import { useSizeClass } from "../utils/hooks";
 import SignUpWithPassword from "../views/SignUpWithPassword";
-import { isLoggedIn } from "../models/config/guards";
+import { isLoggedInAndInvalidLinkCredentials } from "../models/config/guards";
 
 // TODO DEV-484: expand on string handling and localization, extract to
 // a separate JSON file, add capability for client to pass in its own
@@ -527,7 +527,9 @@ const componentForStep = (state) => {
         title: strings.reset.setNewPasswordTitle,
         Component: SetNewPassword,
         props: {
-          requireExistingPassword: isLoggedIn(),
+          requireExistingPassword: isLoggedInAndInvalidLinkCredentials(
+            state.context
+          ),
         },
       };
 
@@ -536,7 +538,9 @@ const componentForStep = (state) => {
         title: strings.reset.setNewPasswordTitle,
         Component: SetNewPassword,
         props: {
-          requireExistingPassword: isLoggedIn(),
+          requireExistingPassword: isLoggedInAndInvalidLinkCredentials(
+            state.context
+          ),
           isLoading: true,
         },
       };

--- a/package/src/models/config/guards.ts
+++ b/package/src/models/config/guards.ts
@@ -104,7 +104,7 @@ export const hasNoActiveFactor = (context: AuthContext<any>) =>
 // If so, we need to check if a second factor is required to log in.
 export const hasLinkQueryParams = (context: AuthContext<any>) => {
   // TODO better off in userfront-core?
-  return !!(context.query.token && context.query.uuid);
+  return !!(context.query?.token && context.query?.uuid);
 };
 
 export const isLoggedIn = () => {

--- a/package/src/models/config/guards.ts
+++ b/package/src/models/config/guards.ts
@@ -117,6 +117,14 @@ export const isLoggedInOrHasLinkCredentials = (context: AuthContext<any>) => {
   return isLoggedIn() || hasLinkQueryParams(context);
 };
 
+export const isLoggedInAndInvalidLinkCredentials = (
+  context: AuthContext<any>
+) => {
+  const validQueryParams =
+    hasLinkQueryParams(context) && context.query?.isValid;
+  return isLoggedIn() && !validQueryParams;
+};
+
 export const isPasswordReset = (context: AuthContext<any>) => {
   return context.config.type === "reset";
 };


### PR DESCRIPTION
Review: Glance
Closes DEV-1129

When initializing the password reset flow check for query params. If they exist (whether logged in or not) we don't need to get the currentPassword.