### PR TITLE
If logged in try to refresh tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18707,7 +18707,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.0.9-alpha.0",
+      "version": "1.0.9-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.0.9-alpha.0",
+  "version": "1.0.9-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.0.9-alpha.0",
+      "version": "1.0.9-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.0.9-alpha.0",
+  "version": "1.0.9-alpha.1",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/src/forms/UniversalForm.jsx
+++ b/package/src/forms/UniversalForm.jsx
@@ -553,6 +553,7 @@ const componentForStep = (state) => {
 
     // Already logged in - for forms on pages without redirect-on-load
     case "alreadyLoggedIn":
+    case "refreshTokens":
       return {
         title: strings.general.welcome,
         Component: AlreadyLoggedIn,

--- a/package/src/models/forms/universal.ts
+++ b/package/src/models/forms/universal.ts
@@ -363,9 +363,9 @@ const universalMachineConfig: AuthMachineConfig = {
         },
         // This is a signup or login form, do shared initialization
 
-        // If there's already a user, proceed.
+        // If there's already a user refresh their tokens, proceed.
         {
-          target: "alreadyLoggedIn",
+          target: "refreshTokens",
           cond: "isLoggedIn",
         },
 
@@ -395,6 +395,21 @@ const universalMachineConfig: AuthMachineConfig = {
           target: "showPreviewAndFetchFlow",
         },
       ],
+    },
+
+    refreshTokens: {
+      invoke: {
+        // Update the tokens
+        // @ts-ignore - TS doesn't infer all of the valid methods correctly
+        src: () => callUserfront({ method: "refresh" }),
+
+        onDone: {
+          target: "alreadyLoggedIn",
+        },
+        onError: {
+          target: "alreadyLoggedIn",
+        },
+      },
     },
 
     // This is a login or signup form, but we're already logged in.

--- a/package/src/services/userfront.ts
+++ b/package/src/services/userfront.ts
@@ -28,7 +28,11 @@ export const overrideUserfrontSingleton = (newSingleton: any) => {
 
 // A type with the keys of all functions in Type
 type Functions<Type> = {
-  [Key in keyof Type]-?: Type[Key] extends Function ? Key : never;
+  [Key in keyof Type]-?: Type[Key] extends Function
+    ? Key
+    : Type[Key] extends object
+    ? Functions<Type[Key]> // Recursively check nested objects
+    : never;
 }[keyof Type];
 
 export interface CallUserfront {


### PR DESCRIPTION
Review Level: Glance
Closes DEV-662

If a user visits the login or signup form and already is logged in attempt to refresh their tokens. On error or success handle a logged in user as we would have before.