### PR TITLE
If logged in with tokens attempt login to update confirmed_at

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18707,7 +18707,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.0.9-alpha.1",
+      "version": "1.0.9-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.0.9-alpha.1",
+  "version": "1.0.9-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.0.9-alpha.1",
+      "version": "1.0.9-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.0.9-alpha.1",
+  "version": "1.0.9-alpha.2",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/src/forms/UniversalForm.jsx
+++ b/package/src/forms/UniversalForm.jsx
@@ -583,7 +583,6 @@ const UniversalForm = ({
 
   // Get the view component, title text, and props corresponding to this state
   const { Component, props, title } = componentForStep(state);
-  console.log(state);
 
   // Construct the default props that are passed to all views
   const defaultProps = {

--- a/package/src/forms/UniversalForm.jsx
+++ b/package/src/forms/UniversalForm.jsx
@@ -553,6 +553,7 @@ const componentForStep = (state) => {
 
     // Already logged in - for forms on pages without redirect-on-load
     case "alreadyLoggedIn":
+    case "initRefreshTokens":
     case "refreshTokens":
       return {
         title: strings.general.welcome,
@@ -582,6 +583,7 @@ const UniversalForm = ({
 
   // Get the view component, title text, and props corresponding to this state
   const { Component, props, title } = componentForStep(state);
+  console.log(state);
 
   // Construct the default props that are passed to all views
   const defaultProps = {

--- a/package/src/models/forms/universal.ts
+++ b/package/src/models/forms/universal.ts
@@ -365,7 +365,7 @@ const universalMachineConfig: AuthMachineConfig = {
 
         // If there's already a user refresh their tokens, proceed.
         {
-          target: "refreshTokens",
+          target: "initRefreshTokens",
           cond: "isLoggedIn",
         },
 
@@ -393,6 +393,20 @@ const universalMachineConfig: AuthMachineConfig = {
         // the preview won't proceed to a specific factor.
         {
           target: "showPreviewAndFetchFlow",
+        },
+      ],
+    },
+
+    initRefreshTokens: {
+      always: [
+        // Try to use the query params if they exist
+        {
+          target: "handleLoginWithLink",
+          cond: "hasLinkQueryParams",
+        },
+        // If no query params, proceed refreshing tokens
+        {
+          target: "refreshTokens",
         },
       ],
     },
@@ -699,6 +713,11 @@ const universalMachineConfig: AuthMachineConfig = {
           },
         ],
         onError: [
+          // If logged in go to refresh tokens
+          {
+            target: "refreshTokens",
+            cond: "isLoggedIn",
+          },
           // If there was a problem logging in with the link token and uuid,
           // go back to first factor selection and show the error.
           // Mark the query params invalid, so we don't infinitely retry them.


### PR DESCRIPTION
Closes DEV-1145

Added state to distinguish automatic refresh based on if you have query params or not. If a user is already logged in we go to `initRefreshTokens`. If there are no query params we can go straight to token refresh, otherwise submit the query params to alert the db. If this fails just go to refresh tokens and finish.