### PR TITLE
[DEV-1438] If the redirect parameter is set always use it as the redirect path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18707,7 +18707,7 @@
     },
     "package": {
       "name": "@userfront/toolkit",
-      "version": "1.0.9",
+      "version": "1.0.10-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/react",
-  "version": "1.0.9",
+  "version": "1.0.10-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/react",
-      "version": "1.0.9",
+      "version": "1.0.10-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/toolkit",
-  "version": "1.0.9",
+  "version": "1.0.10-alpha.0",
   "description": "Bindings and components for authentication with Userfront with React, Vue, other frameworks, and plain JS + HTML",
   "type": "module",
   "directories": {

--- a/package/src/models/config/actions.ts
+++ b/package/src/models/config/actions.ts
@@ -274,14 +274,28 @@ export const markAsSecondFactor = assign({
 // Redirect to the afterLoginPath etc. after signed in, just an alias for the Userfront API method
 export const redirectIfLoggedIn = (context: AuthContext<any>) => {
   if (context.config.redirect !== false) {
-    callUserfront({ method: "redirectIfLoggedIn", args: [] });
+    callUserfront({
+      method: "redirectIfLoggedIn",
+      args: [
+        {
+          redirect: context.config?.redirect,
+        },
+      ],
+    });
   }
 };
 
 // Redirect to the afterLoginPath if the user is already logged in when the form loads, if redirectOnLoad = true
 export const redirectOnLoad = (context: AuthContext<any>) => {
   if (context.config.redirectOnLoad) {
-    callUserfront({ method: "redirectIfLoggedIn", args: [] });
+    callUserfront({
+      method: "redirectIfLoggedIn",
+      args: [
+        {
+          redirect: context.config?.redirect,
+        },
+      ],
+    });
   }
 };
 

--- a/package/src/models/forms/universal.ts
+++ b/package/src/models/forms/universal.ts
@@ -671,6 +671,7 @@ const universalMachineConfig: AuthMachineConfig = {
             args: [
               {
                 method: event.factor?.strategy,
+                redirect: context.config?.redirect,
               },
             ],
           });
@@ -695,6 +696,7 @@ const universalMachineConfig: AuthMachineConfig = {
                 method: "link",
                 token: context.query.token,
                 uuid: context.query.uuid,
+                redirect: context.config?.redirect,
               },
             ],
           });

--- a/package/src/models/views/emailLink.ts
+++ b/package/src/models/views/emailLink.ts
@@ -40,7 +40,7 @@ const emailLinkConfig: AuthMachineConfig = {
             });
           }
           // Login link
-          const arg: Record<string, any> = {
+          const arg: Record<string, string | boolean | undefined> = {
             method: "passwordless",
             email: context.user.email,
             redirect: context.config.redirect,
@@ -86,9 +86,10 @@ const emailLinkConfig: AuthMachineConfig = {
       invoke: {
         // Set the method and email, and name and/or username if present, as arguments
         src: (context) => {
-          const arg: Record<string, string> = {
+          const arg: Record<string, string | boolean | undefined> = {
             method: "passwordless",
             email: context.user.email,
+            redirect: context.config.redirect,
           };
           if (hasValue(context.user.name)) {
             arg.name = context.user.name;


### PR DESCRIPTION
Review level: Glance
Resolves: DEV-1438

Previously we sometimes passed the redirect parameter, we sometimes didn't. Now always redirect to that path if it is set by passing it to CoreJS. Scenarios that didn't follow the expected behavior:
- On email _reset_ link
- On sso login or signup
- On redirect if already logged in
- On redirect after being logged in for some MFA flows