### PR TITLE
DEV-1444 Read linkType from query params and pass to core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7009,15 +7009,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "node_modules/@userfront/core": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.6.8.tgz",
-      "integrity": "sha512-oZ8sHbH8gJYXVTXUHmWLQgx8dHF6j7rcMVi5JGiYKgAzXIApVlR8UiidSQhZyM3d5sFcvCz5Urs+wjwGe1xc4w==",
-      "dependencies": {
-        "axios": "^1.6.2",
-        "js-cookie": "^2.2.1"
-      }
-    },
     "node_modules/@userfront/toolkit": {
       "resolved": "package",
       "link": true
@@ -7742,11 +7733,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -10419,9 +10410,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -18712,7 +18703,7 @@
       "dependencies": {
         "@r2wc/react-to-web-component": "^2.0.2",
         "@react-hook/resize-observer": "^1.2.6",
-        "@userfront/core": "^0.6.8",
+        "@userfront/core": "1.0.0",
         "@xstate/react": "3.0.1",
         "lodash": "^4.17.21",
         "react-icons": "^4.4.0",
@@ -18787,6 +18778,15 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "package/node_modules/@userfront/core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-1.0.0.tgz",
+      "integrity": "sha512-px12zXVkUgxDf1HxaKjYsnOOyEFWZ2kQ6CpQiU6CdUHDAtnb6nnliXefm/IXPb2UlQ5HlzYgDenJaSTMERh+bw==",
+      "dependencies": {
+        "axios": "1.6.8",
+        "js-cookie": "2.2.1"
       }
     },
     "package/node_modules/@vitejs/plugin-react": {
@@ -23916,15 +23916,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "@userfront/core": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.6.8.tgz",
-      "integrity": "sha512-oZ8sHbH8gJYXVTXUHmWLQgx8dHF6j7rcMVi5JGiYKgAzXIApVlR8UiidSQhZyM3d5sFcvCz5Urs+wjwGe1xc4w==",
-      "requires": {
-        "axios": "^1.6.2",
-        "js-cookie": "^2.2.1"
-      }
-    },
     "@userfront/toolkit": {
       "version": "file:package",
       "requires": {
@@ -23942,7 +23933,7 @@
         "@testing-library/react": "^14.0.0",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.6",
-        "@userfront/core": "^0.6.8",
+        "@userfront/core": "1.0.0",
         "@vitejs/plugin-react": "^2.2.0",
         "@vitest/coverage-c8": "^0.25.2",
         "@xstate/graph": "2.0.0-alpha.0",
@@ -23982,6 +23973,15 @@
           "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
           "dev": true,
           "optional": true
+        },
+        "@userfront/core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@userfront/core/-/core-1.0.0.tgz",
+          "integrity": "sha512-px12zXVkUgxDf1HxaKjYsnOOyEFWZ2kQ6CpQiU6CdUHDAtnb6nnliXefm/IXPb2UlQ5HlzYgDenJaSTMERh+bw==",
+          "requires": {
+            "axios": "1.6.8",
+            "js-cookie": "2.2.1"
+          }
         },
         "@vitejs/plugin-react": {
           "version": "2.2.0",
@@ -24623,11 +24623,11 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
@@ -26585,9 +26585,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/package/package.json
+++ b/package/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@r2wc/react-to-web-component": "^2.0.2",
     "@react-hook/resize-observer": "^1.2.6",
-    "@userfront/core": "^0.6.8",
+    "@userfront/core": "1.0.0",
     "@xstate/react": "3.0.1",
     "lodash": "^4.17.21",
     "react-icons": "^4.4.0",

--- a/package/src/index.js
+++ b/package/src/index.js
@@ -24,6 +24,23 @@ Userfront.build = (toolId) => {
   See https://userfront.com/dashboard/toolkit for more information about upgrading to the new toolkit.`);
 };
 
+/**
+ * Override Userfront.init to pass toolkit userfrontSource param into it
+ */
+const UserfrontProxy = new Proxy(Userfront, {
+  get(target, prop) {
+    if (prop === "init") {
+      return (tenantId, options = {}) => {
+        Userfront.init(tenantId, {
+          ...options,
+          userfrontSource: "toolkit",
+        });
+      };
+    }
+    return target[prop];
+  },
+});
+
 /*
  * Dev tools.
  * You probably only want these if you're developing this library.
@@ -47,4 +64,4 @@ export const _devTools = {
   overrideUserfrontSingleton,
 };
 
-export default Userfront;
+export default UserfrontProxy;

--- a/package/src/models/config/actions.ts
+++ b/package/src/models/config/actions.ts
@@ -82,10 +82,12 @@ export const readQueryParams = assign((context: AuthContext<View>) => {
   }
   const uuid = getQueryAttr("uuid");
   const token = getQueryAttr("token");
+  const linkType = getQueryAttr("type");
   return {
     query: {
       uuid,
       token,
+      linkType,
       isValid: true,
     },
   };

--- a/package/src/models/forms/universal.ts
+++ b/package/src/models/forms/universal.ts
@@ -696,6 +696,7 @@ const universalMachineConfig: AuthMachineConfig = {
                 method: "link",
                 token: context.query.token,
                 uuid: context.query.uuid,
+                linkType: context.query.linkType,
                 redirect: context.config?.redirect,
               },
             ],

--- a/package/src/models/forms/universal.ts
+++ b/package/src/models/forms/universal.ts
@@ -329,7 +329,10 @@ const universalMachineConfig: AuthMachineConfig = {
           // @ts-ignore
           callUserfrontSync({
             method: "init",
-            args: [context.config.tenantId!],
+            args: [
+              context.config.tenantId!,
+              { options: { userfrontSource: "toolkit" } },
+            ],
           });
           return context.config.tenantId;
         },

--- a/package/src/models/types.ts
+++ b/package/src/models/types.ts
@@ -150,6 +150,7 @@ export type View =
 export type Query = {
   token?: string;
   uuid?: string;
+  linkType?: string;
   isValid?: boolean;
 };
 


### PR DESCRIPTION
Review level: Glance
Resolves: DEV-1444

When we land on a toolkit page with query params read the uuid, token, AND type. Pass the type as `linkType` to userfront-core when logging in with an email link. This allows for users to be redirected to the `afterSignupPath` if they had a welcome email.

TODO
- [x] update to the new version of core when it is deployed